### PR TITLE
Prevent NaNs from propagating to Draw.

### DIFF
--- a/src/parse-geometry.js
+++ b/src/parse-geometry.js
@@ -178,6 +178,7 @@ function BikeGeometry(initMeasurements, settings) {
                 if (this.resolvedPoint[property] !== this.resolvedPoint[property]) {
                     this.error = true;
                     this.error_parameters.push(property);
+                    delete this.resolvedPoint[property];
                 }
             }
         }

--- a/src/visual-bike.js
+++ b/src/visual-bike.js
@@ -33,7 +33,10 @@ function drawBikeComparison(bike_geometries, settings) {
         },
         start_zoom,
         bbox;
+
+    paper.zpd('destroy')
     paper.clear();
+
 
     function drawNames(bikeGeometries, paper, start_x, start_y) {
         var start_x = start_x || 0,


### PR DESCRIPTION
Following simple error detection, stop any error NaNs in the Geometry computation, rather than passing bad values to Draw.